### PR TITLE
Use process.env to retrieve $EDITOR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const COMMANDS = {
 
 const GITHUB_WEBSITE = "https://github.com";
 const TEMP_DIR = `${tmpdir}${uuid()}`;
-const EDITOR = `$EDITOR`;
+const EDITOR = process.env.EDITOR;
 
 const logger = (message: string, type: "log" | "info" | "error") => (
   ...args: any[]
@@ -53,5 +53,5 @@ const logger = (message: string, type: "log" | "info" | "error") => (
   }
 
   spinner.end();
-  cp.spawn(editor, [TEMP_DIR], { stdio: "inherit" });
+  cp.spawn(editor, [TEMP_DIR], { stdio: "inherit", env: process.env });
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,5 +53,5 @@ const logger = (message: string, type: "log" | "info" | "error") => (
   }
 
   spinner.end();
-  cp.spawn(editor, [TEMP_DIR], { stdio: "inherit", env: process.env });
+  cp.spawn(editor, [TEMP_DIR], { stdio: "inherit", shell: true });
 })();


### PR DESCRIPTION
The `$` notation to fetch environment variables does not work on windows. Instead, get the environment variable from NodeJS using `process.env.EDITOR`. 

The `spawn` command by default does not use the systems environment variables. The windows variable `PATH` is not included, causing some applications not to be resolved. ~~Passed `process.env` through to `spawn` to make sure paths are resolved correctly windows.~~ correction: passed `shelll: true` to make sure commands get resolved correctly with `PATH`.